### PR TITLE
fix: permission for run gradlew

### DIFF
--- a/gesco/Dockerfile
+++ b/gesco/Dockerfile
@@ -10,6 +10,9 @@ COPY gradlew /app/
 COPY build.gradle /app/
 COPY settings.gradle /app/
 
+# Adicionar permissão de execução para o gradlew
+RUN chmod +x ./gradlew
+
 # Baixar as dependências do Gradle
 RUN ./gradlew build --no-daemon || return 0
 


### PR DESCRIPTION
O docker file tava tentando executar o gradlew, mas como não tinha permissão dava erro 
Segue o print do erro :
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/4e760a38-8b07-4b23-983a-ae9c4286cca0">
